### PR TITLE
Add an extra check when game is ran locally

### DIFF
--- a/src/game/loader/XML.js
+++ b/src/game/loader/XML.js
@@ -36,11 +36,14 @@ Game.Loader.XML.createFromXML = function(url, callback)
 Game.Loader.XML.prototype.asyncLoadXml = function(url)
 {
     var loader = this;
+    var isLoadedLocally = function(xhr) {
+        return xhr.status === 0 && xhr.responseURL.match(/^file:/);
+    };
     return new Promise(function(resolve, reject) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', url);
         xhr.addEventListener('load', function() {
-            if (xhr.status === 200) {
+            if (xhr.status === 200 || isLoadedLocally(xhr)) {
                 var parser = new DOMParser();
                 var doc = parser.parseFromString(xhr.responseText, 'text/xml');
                 doc.baseURL = url;


### PR DESCRIPTION
Hej @pomle !

The first issue I ran into when I cloned your repo and ran it locally was this one
![skarmavbild 2016-06-11 kl 09 15 25](https://cloud.githubusercontent.com/assets/587388/15983862/47ba2a8e-2fb5-11e6-9e45-cf730034030a.png)

It occurred because the request was not really sent (due to the cross-site origin restriction) [[1](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#XMLHttpRequests_being_stopped)]. So I just added check when the game is ran locally.

This is how I reproduced this bug:
1. git clone <your repo>
2. npm start && npm build
3. open -a "Google Chrome" --args --allow-file-access-from-files
4. Open local URL (`file:///Users/serch/dev/megamanjs/build/index.html`)

And I was using:
Mac OSX El Capital 10.11.5
Google Chrome 50.0.2661.102 (64-bit)