### PR TITLE
Correct three.js require spelling.

### DIFF
--- a/tools/concat-js.js
+++ b/tools/concat-js.js
@@ -9,7 +9,7 @@ scripts.forEach((src) => {
   js += fs.readFileSync(__dirname + '/../src/' + src, 'utf8') + '\n';
 });
 
-global.THREE = require('THREE');
+global.THREE = require('three');
 vm.runInThisContext(js);
 
 process.stdout.write(js);


### PR DESCRIPTION
Capitals is wrong but works on some file systems like OSX and Win.