### PR TITLE
Use performance.now to get initial time stamp.

### DIFF
--- a/src/engine/Timer.js
+++ b/src/engine/Timer.js
@@ -26,11 +26,9 @@ class Timer
     eventLoop(millis)
     {
         if (millis !== undefined) {
-            const seconds = millis / 1000;
-            if (this._timeLastEvent != null) {
-                this.updateTime(seconds - this._timeLastEvent);
-            }
-            this._timeLastEvent = seconds;
+            const diff = millis - this._timeLastEvent;
+            this.updateTime(diff / 1000);
+            this._timeLastEvent = millis;
         }
         this.events.trigger(this.EVENT_RENDER);
 
@@ -49,7 +47,7 @@ class Timer
             return;
         }
         this._isRunning = true;
-        this._timeLastEvent = null;
+        this._timeLastEvent = performance.now();
         this._enqueue();
     }
     setTimeStretch(multiplier)

--- a/test/mocks/requestanimationframe-mock.js
+++ b/test/mocks/requestanimationframe-mock.js
@@ -11,6 +11,7 @@ function mock()
 {
   reset();
   global.window = {};
+  global.performance = { now: () => time }
   global.requestAnimationFrame = _interface.requestAnimationFrame;
   global.cancelAnimationFrame = _interface.cancelAnimationFrame;
 }
@@ -18,6 +19,7 @@ function mock()
 function clean()
 {
   delete global.window;
+  delete global.performance;
   delete global.requestAnimationFrame;
   delete global.cancelAnimationFrame;
 }
@@ -40,6 +42,7 @@ function reset()
 
 function triggerAnimationFrame(millis) {
   frameId++;
+  time = millis;
   const iterate = callbacks;
   callbacks = [];
   iterate.forEach(callback => {

--- a/test/unit/game.js
+++ b/test/unit/game.js
@@ -12,21 +12,27 @@ const Game = env.Game;
 const Scene = env.Game.Scene;
 
 describe('Game', function() {
+  beforeEach(function() {
+    WebGLRendererMock.mock();
+    RequestAnimationFrameMock.mock();
+    AudioContextMock.mock();
+  });
+
+  afterEach(function() {
+    WebGLRendererMock.clean();
+    RequestAnimationFrameMock.clean();
+    AudioContextMock.clean();
+  });
+
   function createGame()
   {
-    AudioContextMock.mock();
-    WebGLRendererMock.mock();
     const game = new Game;
-    AudioContextMock.clean();
-    WebGLRendererMock.clean();
     return game;
   }
 
   function createScene()
   {
-    RequestAnimationFrameMock.mock();
     const scene = new Scene;
-    RequestAnimationFrameMock.clean();
     return scene;
   }
 
@@ -118,13 +124,12 @@ describe('Game', function() {
       game.setPlaybackSpeed(1.16);
       game.setScene(scene);
       scene.world.events.bind(scene.world.EVENT_UPDATE, updateSpy);
-      RequestAnimationFrameMock.triggerAnimationFrame(0);
       RequestAnimationFrameMock.triggerAnimationFrame(219);
       expect(updateSpy.callCount).to.be(1);
       expect(updateSpy.lastCall.args).to.eql([0.25404, 0.24999999999999997]);
       RequestAnimationFrameMock.triggerAnimationFrame(519);
       expect(updateSpy.callCount).to.be(2);
-      expect(updateSpy.lastCall.args).to.eql([0.34800000000000003, 0.6000000000000003]);
+      expect(updateSpy.lastCall.args).to.eql([0.348, 0.6000000000000003]);
     });
   });
 

--- a/test/unit/timer.js
+++ b/test/unit/timer.js
@@ -49,22 +49,23 @@ describe('Timer', function() {
       const timer = createTimer();
       timer.run();
       timer.pause();
-      RequestAnimationFrameMock.triggerAnimationFrame(0);
       RequestAnimationFrameMock.triggerAnimationFrame(100);
       expect(requestAnimationFrame.callCount).to.be(1);
       teardown();
     });
 
-    it('should propagate delta time of requestAnimationFrame time in seconds', function() {
+    it('should propagate delta time of requestAnimationFrame in seconds', function() {
       setup();
       const timer = createTimer();
       const updateSpy = sinon.spy();
       timer.events.bind(timer.EVENT_UPDATE, updateSpy);
       timer.run();
-      RequestAnimationFrameMock.triggerAnimationFrame(0);
       RequestAnimationFrameMock.triggerAnimationFrame(200);
       expect(updateSpy.callCount).to.equal(1);
-      expect(updateSpy.getCall(0).args[0]).to.equal(0.2);
+      expect(updateSpy.getCall(0).args[0]).to.equal(0.200);
+      RequestAnimationFrameMock.triggerAnimationFrame(550);
+      expect(updateSpy.callCount).to.equal(2);
+      expect(updateSpy.getCall(1).args[0]).to.equal(0.350);
       teardown();
     });
 
@@ -137,22 +138,22 @@ describe('Timer', function() {
       const callback = sinon.spy();
       timer.events.bind(timer.EVENT_UPDATE, callback);
       timer.setTimeStretch(2.13);
-      timer.updateTime(.3);
+      timer.updateTime(0.3);
       expect(callback.callCount).to.equal(1);
-      expect(callback.lastCall.args[0]).to.be(0.6389999999999999);
+      expect(callback.lastCall.args[0]).to.be.within(0.6389, 0.6399);
       teardown();
     });
   });
 
   describe('#updateTime', function() {
-    it('should trigger EVENT_UPDATE', function() {
+    it('should trigger EVENT_UPDATE with time in seconds', function() {
       setup();
       const timer = createTimer();
       const callback = sinon.spy();
       timer.events.bind(timer.EVENT_UPDATE, callback);
-      timer.updateTime(.3);
+      timer.updateTime(1.234);
       expect(callback.callCount).to.equal(1);
-      expect(callback.lastCall.args[0]).to.equal(.3);
+      expect(callback.lastCall.args[0]).to.equal(1.234);
       teardown();
     });
   });


### PR DESCRIPTION
Avoids double requestAnimationFrame on resume.